### PR TITLE
Fix juros no arquivo de remessa

### DIFF
--- a/src/Remessa/CNAB240/SegmentP.php
+++ b/src/Remessa/CNAB240/SegmentP.php
@@ -327,7 +327,7 @@ class SegmentP extends LineAbstract
             'seq' => '29.3P',
             'start' => 127,
             'end' => 141,
-            'size' => 15,
+            'size' => 16,
             'default' => 0,
             'type' => 'money',
             'description' => 'Juros de Mora por Dia/Taxa ao Mês


### PR DESCRIPTION
Falta uma posição a esquerda no campo para juros, por exemplo:
1,50% fica cormatado como 15,00%