### PR TITLE
Revert "Fix juros no arquivo de remessa"

### DIFF
--- a/src/Remessa/CNAB240/SegmentP.php
+++ b/src/Remessa/CNAB240/SegmentP.php
@@ -327,7 +327,7 @@ class SegmentP extends LineAbstract
             'seq' => '29.3P',
             'start' => 127,
             'end' => 141,
-            'size' => 16,
+            'size' => 15,
             'default' => 0,
             'type' => 'money',
             'description' => 'Juros de Mora por Dia/Taxa ao Mês


### PR DESCRIPTION
Creio que vamos precisar tratar outras questões referentes a remessa em nossa lógica de aplicação. Encontramos um bug com a alteração (na utilização de juros, pode gerar um dígito a mais).

Solicito que voltemos esta alteração até termos um patch adequado (caso necessário, espero que não precisemos alterar a lib e seja viável ajustar apenas na nossa ponta)